### PR TITLE
Make compile work with java-9

### DIFF
--- a/multirelease-nine/pom.xml
+++ b/multirelease-nine/pom.xml
@@ -16,6 +16,8 @@
 
     <properties>
         <javaVersion>9</javaVersion>
+        <maven.compiler.source>${javaVersion}</maven.compiler.source>
+        <maven.compiler.target>${javaVersion}</maven.compiler.target>
         <maven.install.skip>true</maven.install.skip>
     </properties>
 


### PR DESCRIPTION
Java-9 omits the 1. prefix that is inherited from the main pom.xml file, so redefining the relevant variables locally to avoid the conflict